### PR TITLE
Add CARAFE installation dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -39,4 +39,5 @@ setup(
     packages=find_packages(exclude=('test', )),
     cmdclass={'build_ext': BuildExtension},
     zip_safe=False,
+    install_requires=['torch'],
 )


### PR DESCRIPTION
CARAFE has dependency on `torch` and when installing with `pip` one has to make sure that `torch` is installed first, otherwise the installation raises an error. A much more problematic case is when someone wants to install it with [`poetry`](https://python-poetry.org/) in that case the installation will fail instantly as the `setup.py` does not indicate installation requirements. This PR solves the problem by simply adding `install_requires=['torch']` attribute to the `setuptools.setup` function. 

## Steps to produce
1. install poetry: `pip install poetry`
2. install CARAFE with poetry: `poetry add git+https://github.com/myownskyW7/CARAFE.git@master`

### Result
```bash
  PackageInfoError

  Unable to determine package info for path: /tmp/pypoetry-git-CARAFEvm31k1tj
  
  Fallback egg_info generation failed.
  
  Command ['/tmp/tmp09_lpyl6/.venv/bin/python', 'setup.py', 'egg_info'] errored with the following return code 1, and output: 
  Traceback (most recent call last):
    File "setup.py", line 3, in <module>
      from torch.utils.cpp_extension import BuildExtension, CUDAExtension
  ModuleNotFoundError: No module named 'torch'

  at ~/.virtualenvs/parsing/lib/python3.6/site-packages/poetry/inspection/info.py:503 in _pep517_metadata
      499│                     venv.run("python", "setup.py", "egg_info")
      500│                     return cls.from_metadata(path)
      501│                 except EnvCommandError as fbe:
      502│                     raise PackageInfoError(
    → 503│                         path, "Fallback egg_info generation failed.", fbe
      504│                     )
      505│                 finally:
      506│                     os.chdir(cwd.as_posix())
```

### Expected result:
```bash
Updating dependencies
Resolving dependencies... (1.1s)

Writing lock file

Package operations: 1 install, 0 updates, 0 removals

  • Installing carafe (0.0.1 c24cd45)
```